### PR TITLE
BUGFIX: 0-length strings are valid on the protocol

### DIFF
--- a/osc/message.go
+++ b/osc/message.go
@@ -269,9 +269,6 @@ func (m *Message) readArguments(reader *bytes.Buffer) error {
 			if err != nil {
 				return err
 			}
-			if str[0] == 0 {
-				return fmt.Errorf("readArguments: empty string")
-			}
 			// Remove the padding bytes
 			reader.Next(padBytesNeeded(len(str)))
 			str = str[:len(str)-1]

--- a/osc/message.go
+++ b/osc/message.go
@@ -269,9 +269,16 @@ func (m *Message) readArguments(reader *bytes.Buffer) error {
 			if err != nil {
 				return err
 			}
-			// Remove the padding bytes
-			reader.Next(padBytesNeeded(len(str)))
-			str = str[:len(str)-1]
+
+			if str[0] == 0 {
+				str = str[:len(str)-1]
+				reader.Next(padBytesNeeded(len(str)))
+			} else {
+				// Remove the padding bytes
+				reader.Next(padBytesNeeded(len(str)))
+				str = str[:len(str)-1]
+
+			}
 
 			m.Arguments = append(m.Arguments, str)
 


### PR DESCRIPTION
OSC v1.0 spesification doesn't demand that the strings aren't empty, thus a 0-lenght string is completely valid argument and commonly used in real world.