### PR TITLE
FEATURE: add server.Close()

### DIFF
--- a/osc/server.go
+++ b/osc/server.go
@@ -13,6 +13,7 @@ type Server struct {
 	Addr        string
 	Dispatcher  Dispatcher
 	ReadTimeout time.Duration
+	close       func() error
 }
 
 // ListenAndServe retrieves incoming OSC packets and dispatches the retrieved
@@ -26,9 +27,18 @@ func (s *Server) ListenAndServe() error {
 	if err != nil {
 		return err
 	}
+	s.close = ln.Close
 	defer ln.Close()
 
 	return s.Serve(ln)
+}
+
+// Close shuts down the server and closes it's upd connection
+func (s *Server) Close() error {
+	if s.close != nil {
+		return s.close()
+	}
+	return nil
 }
 
 // Serve retrieves incoming OSC packets from the given connection and dispatches


### PR DESCRIPTION
This is used for gracefully closing the port if needed. I'm using this for reloading the configuration during run time without needing a complete restart of the application. 

Proper use needs a special case added to code calling ListenAndServe() error handling to catch net.OpErr for the closed socket. It could also be handled inside ListenAndServe() but I prefer not eating errors in such cases.